### PR TITLE
Separated FFMPEG_PATH variable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ Pulse recognition by video stream
 
 
 To compile and run please define these environment variables:
-FFMPEG_PATH - ffmpeg library
+FFMPEG_INCLUDE_PATH - ffmpeg library headers
+FFMPEG_LIB_PATH - ffmpeg static library files
 FFTW_PATH - fftw library

--- a/Vpulse.pro
+++ b/Vpulse.pro
@@ -1,9 +1,14 @@
 TARGET = Vpulse
 TEMPLATE = subdirs
-SUBDIRS = lib exec tests
+SUBDIRS = lib exec
 
 lib.file = lib/lib.pro
 exec.file = exec/exec.pro
-tests.file = tests/tests.pro
+#tests.file = tests/tests.pro
 
 CONFIG += ordered
+
+HEADERS += Calculator.h\
+    Mat.h \
+    Processor.h \
+    Videoreader.h \

--- a/lib/lib.pro
+++ b/lib/lib.pro
@@ -12,8 +12,8 @@ SOURCES +=\
     Calculator.cpp \
 
 INCLUDEPATH += $$(FFTW_PATH)
-INCLUDEPATH += $$(FFMPEG_PATH)/include
+INCLUDEPATH += $$(FFMPEG_INCLUDE_PATH)
 INCLUDEPATH += ..
 
 LIBS += -L$$(FFTW_PATH) -llibfftw3-3
-LIBS += -L$$(FFMPEG_PATH)/lib/ -lavcodec-55 -lavformat-55 -lswscale-2 -lavutil-52
+LIBS += -L$$(FFMPEG_LIB_PATH) -lavcodec -lavformat -lswscale -lavutil

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -16,6 +16,6 @@ INCLUDEPATH += ..
 INCLUDEPATH += $$(CXXTEST_PATH)
 
 LIBS += -L$$(FFTW_PATH) -llibfftw3-3
-LIBS += -L$$(FFMPEG_PATH)/lib/ -lavcodec-55 -lavformat-55 -lswscale-2 -lavutil-52
+LIBS += -L$$(FFMPEG_PATH)/lib/ -lavcodec -lavformat -lswscale -lavutil
 LIBS += -L../lib/release -lVpulse
 


### PR DESCRIPTION
Separated FFMPEG_PATH variable into FFMPEG_INCLUDE_PATH and FFMPEG_LIB_PATH because of different library structure on different OS.
